### PR TITLE
Explicit deleter for request callback.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erty"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Evgeny Safronov <division494@gmail.com>"]
 
 [lib]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+liberty (0.1.3) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Fixed: `not-ever-called` callback resource leak.
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Wed, 28 Mar 2018 18:35:35 +0300
+
 liberty (0.1.2) unstable; urgency=low
 
   * Feat: complete build by debian/rules.

--- a/include/liberty/liberty.h
+++ b/include/liberty/liberty.h
@@ -10,6 +10,7 @@ struct liberty_http_request;
 struct liberty_http_response;
 
 typedef void (*complete_callback)(const liberty_http_error *, const liberty_http_response *, void *);
+typedef void (*delete_callback)(void *);
 
 const char *liberty_error_extra(const liberty_http_error *error);
 size_t liberty_error_extra_size(const liberty_http_error *error);
@@ -22,7 +23,7 @@ int liberty_http_request_get(liberty_http_request *request);
 int liberty_http_request_post(liberty_http_request *request);
 int liberty_http_request_url(liberty_http_request *request, const char *data, size_t size);
 int liberty_http_request_data(liberty_http_request *request, const char *data, size_t size);
-void liberty_http_request_complete_callback(liberty_http_request *request, complete_callback, void *data);
+void liberty_http_request_complete_callback(liberty_http_request *request, complete_callback, void *data, delete_callback);
 
 int liberty_http_response_code(const liberty_http_response *response);
 const char *liberty_http_response_body(const liberty_http_response *response);

--- a/include/liberty/liberty.h
+++ b/include/liberty/liberty.h
@@ -10,7 +10,6 @@ struct liberty_http_request;
 struct liberty_http_response;
 
 typedef void (*complete_callback)(const liberty_http_error *, const liberty_http_response *, void *);
-typedef void (*delete_callback)(void *);
 
 const char *liberty_error_extra(const liberty_http_error *error);
 size_t liberty_error_extra_size(const liberty_http_error *error);
@@ -23,7 +22,7 @@ int liberty_http_request_get(liberty_http_request *request);
 int liberty_http_request_post(liberty_http_request *request);
 int liberty_http_request_url(liberty_http_request *request, const char *data, size_t size);
 int liberty_http_request_data(liberty_http_request *request, const char *data, size_t size);
-void liberty_http_request_complete_callback(liberty_http_request *request, complete_callback, void *data, delete_callback);
+void liberty_http_request_complete_callback(liberty_http_request *request, complete_callback, void *data);
 
 int liberty_http_response_code(const liberty_http_response *response);
 const char *liberty_http_response_body(const liberty_http_response *response);

--- a/include/liberty/liberty.hpp
+++ b/include/liberty/liberty.hpp
@@ -31,10 +31,13 @@ public:
     template<typename F>
     auto set_complete_callback(F fn) -> void {
         std::unique_ptr<F> holder(new F(std::move(fn)));
-        liberty_http_request_complete_callback(request, [](const liberty_http_error* error, const liberty_http_response* response, void* data) {
-            std::unique_ptr<F> holder(static_cast<F*>(data));
-            (*holder)(error, response);
-        }, holder.release());
+
+        const auto deleter = +[] (void* data) { delete static_cast<F*>(data); };
+        const auto completion = +[] (const liberty_http_error* error, const liberty_http_response* response, void* data) {
+            (*static_cast<F*>(data))(error, response);
+        };
+
+        liberty_http_request_complete_callback(request, completion, holder.release(), deleter);
     }
 
     auto into_inner() && -> liberty_http_request* {

--- a/include/liberty/liberty.hpp
+++ b/include/liberty/liberty.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "liberty.h"
 
 namespace liberty {

--- a/include/liberty/liberty.hpp
+++ b/include/liberty/liberty.hpp
@@ -33,13 +33,10 @@ public:
     template<typename F>
     auto set_complete_callback(F fn) -> void {
         std::unique_ptr<F> holder(new F(std::move(fn)));
-
-        const auto deleter = +[] (void* data) { delete static_cast<F*>(data); };
-        const auto completion = +[] (const liberty_http_error* error, const liberty_http_response* response, void* data) {
-            (*static_cast<F*>(data))(error, response);
-        };
-
-        liberty_http_request_complete_callback(request, completion, holder.release(), deleter);
+        liberty_http_request_complete_callback(request, [](const liberty_http_error* error, const liberty_http_response* response, void* data) {
+            std::unique_ptr<F> holder(static_cast<F*>(data));
+            (*holder)(error, response);
+        }, holder.release());
     }
 
     auto into_inner() && -> liberty_http_request* {


### PR DESCRIPTION
For some (yet unclear) reasons it seems that HttpClient event loop could leak cpp callbacks spawned by `core::handle` in some situations without calling them, but callbacks should be called as they should realize allocated (binded) resources.

This patch defines explicit deleter callback to be send to rust (via `liberty_http_request_complete_callback` arg), which will be called on Callback (actually introduced by this PR wrapper CallbackWithArgs) drop.

